### PR TITLE
added jekyll-feed as plugin-in

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# A sample Gemfile
+source "http://rubygems.org"
+
+gem 'github-pages'
+gem 'jekyll-feed'

--- a/_config.yaml
+++ b/_config.yaml
@@ -1,3 +1,5 @@
 name: Paul Withers Blog
 markdown: kramdown
 permalink: /blog/:year/:month/:day/:title
+gems:
+  - jekyll-feed


### PR DESCRIPTION
Added into _config, also in Gemfile, which allows easy dep install for ruby via [bundler](http://bundler.io/), install via `gem install bundler`, then install deps with `bundle install` w/i project repo.

The only major shift in local implementation is that your preview will need to be executed by bundler (e.g.- `bundle exec jekyll serve`).